### PR TITLE
Upgrade Experimental Helix branch to most recent

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -9,7 +9,7 @@
     nur.url = "github:nix-community/NUR";
     devshell.url = "github:numtide/devshell";
     flake-utils.url = "github:numtide/flake-utils";
-    helix.url = "github:SoraTenshi/helix/experimental";
+    helix.url = "github:SoraTenshi/helix/experimental-22.12";
     hyprland.url = "github:hyprwm/Hyprland/";
     xdg-portal-hyprland.url = "github:hyprwm/xdg-desktop-portal-hyprland";
     hyprland-contrib.url = "github:hyprwm/contrib";


### PR DESCRIPTION
Since i have made a new branch since the 22.12 release.

I think i will also continue this trend.
